### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/mediumish.js
+++ b/assets/js/mediumish.js
@@ -117,7 +117,8 @@ jQuery(document).ready(function($){
 var loadDeferredStyles = function () {
 	var addStylesNode = document.getElementById("deferred-styles");
 	var replacement = document.createElement("div");
-	replacement.innerHTML = addStylesNode.textContent;
+	var textNode = document.createTextNode(addStylesNode.textContent);
+	replacement.appendChild(textNode);
 	document.body.appendChild(replacement);
 	addStylesNode.parentElement.removeChild(addStylesNode);
 };


### PR DESCRIPTION
Potential fix for [https://github.com/OkanUzun/okanuzun.com-mediumish/security/code-scanning/5](https://github.com/OkanUzun/okanuzun.com-mediumish/security/code-scanning/5)

To fix the issue, we need to ensure that the content of `addStylesNode.textContent` is not directly interpreted as HTML. Instead of assigning it to `innerHTML`, we can create a text node and append it to the `replacement` element. This approach ensures that the content is treated as plain text, not HTML, thereby preventing any potential XSS vulnerabilities.

The fix involves replacing the line `replacement.innerHTML = addStylesNode.textContent;` with code that creates a text node using `document.createTextNode` and appends it to the `replacement` element.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
